### PR TITLE
create-issue: retry if user doesn't have project permissions

### DIFF
--- a/scripts/btrfs-create-issue
+++ b/scripts/btrfs-create-issue
@@ -27,7 +27,9 @@ read -p "Enter an existing issue to update (enter to create new): " issue
 if [ "$issue" == "" ]
 then
 	gh issue create --title "${2}" --project "Btrfs kernel patch review" \
-		-R "btrfs/linux" --body "${TEMPLATE}"
+		-R "btrfs/linux" --body "${TEMPLATE}" \
+	|| (echo "Skipping adding to review queue" \
+	    && gh issue create --title "${2}" -R "btrfs/linux" --body "${TEMPLATE}")
 else
 	TEMPLATE=$(_json_escape "${TEMPLATE}")
 	TITLE=$(_json_escape "${2}")


### PR DESCRIPTION
For btrfs patch submitters who do not yet have project permissions,
btrfs-create-issue currently fails altogether due to lack of permission.
This makes their patch mailing-list-only, making it harder to work in
the project workflow. Adding a retry without the project set means an
issue will be created; the issue will be outside the project, but at
least it exists, making it easier to add to the project workflow.