### PR TITLE
scripts/send-patches: allow all arugments to be specified by commandline

### DIFF
--- a/scripts/btrfs-create-issue
+++ b/scripts/btrfs-create-issue
@@ -9,30 +9,61 @@ _json_escape() {
 	printf '%s' "$1" | python -c 'import json,sys; print(json.dumps(sys.stdin.read()))'
 }
 
-[ "$#" -ne 2 ] && _exit "btrfs-create-usage <MSGID> <SUBJECT>"
-
 gh --help > /dev/null
 [ $? -ne 0 ] && _exit "Please install gh to use this tool (https://cli.github.com/manual/installation)"
 
-MSG_ID=$1
+TEMP=$(getopt -o 'i:m:t:' --long 'issue:,message-id:,title:' -n 'btrfs-create-issue' -- "$@")
+
+[ $? -ne 0 ] && _exit "getopt failed"
+
+eval set -- "$TEMP"
+unset TEMP
+
+while true; do
+	case "$1" in
+		'-i'|'--issue')
+			issue="$2"
+			shift 2
+			continue
+		;;
+		'-m'|'--message-id')
+			messageid="$2"
+			shift 2
+			continue
+		;;
+		'-t'|'--title')
+			title="$2"
+			shift 2
+			continue
+		;;
+		'--')
+			shift
+			break
+		;;
+		*)
+			_exit "getopt failed"
+		;;
+	esac
+done
+
+[ -z "$title" ] && _exit "-t/--title must be specified"
+[ -z "$messageid" ] && _exit "-m/--message-id must be specified"
 
 TEMPLATE="Link to patches
 
-https://lore.kernel.org/linux-btrfs/${MSG_ID}/
+https://lore.kernel.org/linux-btrfs/${messageid}/
 
-b4 am ${MSG_ID}"
-
-read -p "Enter an existing issue to update (enter to create new): " issue
+b4 am ${messageid}"
 
 if [ "$issue" == "" ]
 then
-	gh issue create --title "${2}" --project "Btrfs kernel patch review" \
+	gh issue create --title "${title}" --project "Btrfs kernel patch review" \
 		-R "btrfs/linux" --body "${TEMPLATE}" \
 	|| (echo "Skipping adding to review queue" \
-	    && gh issue create --title "${2}" -R "btrfs/linux" --body "${TEMPLATE}")
+	    && gh issue create --title "${title}" -R "btrfs/linux" --body "${TEMPLATE}")
 else
 	TEMPLATE=$(_json_escape "${TEMPLATE}")
-	TITLE=$(_json_escape "${2}")
+	TITLE=$(_json_escape "${title}")
 	echo "{\"body\": ${TEMPLATE}}" |
 		gh api "repos/btrfs/linux/issues/${issue}/comments" --input=-
 	echo "{\"title\": ${TITLE}}" | \

--- a/scripts/btrfs-send-patches
+++ b/scripts/btrfs-send-patches
@@ -6,21 +6,37 @@ _exit() {
 }
 
 DIR=$(dirname $0)
-[ "$#" -ne 1 ] && _exit "Must specify a file or directory to send"
 
 MSG_ID=""
 EMAIL=""
+skip_issue_arg=0
 
-if [ -f $1 ]
-then
-	EMAIL=$1
-elif [ -d $1 ]
-then
-	EMAIL=$(find $1 -name '*cover\-letter.patch')
-	[ -f $EMAIL ] || _exit "You must remember to use --cover-letter"
-else
-	_exit "Must specify a file or directory to send"
-fi
+send_email_args=()
+for i in "$@"; do
+	# Catch '-i'|'--issue' and remove them from the argument list
+	if [ "$skip_issue_arg" == "1" ]; then
+		issue="$i"
+		skip_issue_arg=0
+		continue;
+	fi
+	if [ "$i" == "-i" -o "$i" == "--issue" ]; then
+		skip_issue_arg=1
+		continue
+	fi
+
+	# Catch the first directory/file as the email
+	if [ -f "$i" -a -z "$EMAIL" ]; then
+		EMAIL="$i"
+	fi
+	if [ -d "$i" -a -z "$EMAIL" ]; then
+		EMAIL=$(find $1 -name '*cover\-letter.patch')
+		[ -f $EMAIL ] || _exit "You must remember to use --cover-letter"
+	fi
+	# All the other parameters will be passed to git-send-email
+	send_email_args+=("$i")
+done
+
+[ -z "$EMAIL" ] && _exit "Must specify a file or directory to send"
 
 MSG_ID=$(grep 'Message-Id' ${EMAIL})
 [ $? -ne 0 ] && _exit "Message-Id wasn't present in the patch provided"
@@ -33,5 +49,10 @@ MSG_ID=$(echo ${MSG_ID} | \
 SUBJECT=$(egrep '^Subject:' ${EMAIL} | head -n1 | cut -c 10-)
 [ $? -ne 0 ] && _exit "Subject wasn't present in the patch provided"
 
-git send-email $1 || _exit "Couldn't send the email"
-"$DIR"/btrfs-create-issue "${MSG_ID}" "${SUBJECT}"
+# All the remaining arguments are passed to git send-email directly
+git send-email ${send_email_args[@]} || _exit "Couldn't send the email"
+if [ -z "$issue" ]; then
+	"$DIR"/btrfs-create-issue -m "${MSG_ID}" -t "${SUBJECT}"
+else
+	"$DIR"/btrfs-create-issue -m "${MSG_ID}" -t "${SUBJECT}" -i "$issue"
+fi


### PR DESCRIPTION
!!! THIS PATCH WILL CAUSE ARUGMENT LIST CHANGE !!!

This patch allows one to send patches and create issue just in one
command line without any interactive input.

The new format would look like:

  $ ./scripts/btrfs-send-patches --to wqu@suse.com --issue 521 /tmp/patches/*.patch

The `btrfs-send-patches` script will catch '-i' or '--issue' and its
argument manually, then passing all the remaining arguments to `git
send-email` directly.

Above example will send the patch to the address, and update the issue 521.

If no '-i' or '--issue' is specified, `btrfs-send-patch` will default to
create a new case.

Although this will change the script argument list, it should be worthy
for the ability to send the patch in one commandline.

Signed-off-by: Qu Wenruo <wqu@suse.com>