### PR TITLE
scripts: use "grep -E" to replace egrep

### DIFF
--- a/scripts/btrfs-send-patches
+++ b/scripts/btrfs-send-patches
@@ -46,7 +46,7 @@ MSG_ID=$(echo ${MSG_ID} | \
 [ $? -ne 0 ] && _exit "Message-Id couldn't be extracted from the patch provided"
 
 # Just incase somebody includes 'Subject:' in their commit body
-SUBJECT=$(egrep '^Subject:' ${EMAIL} | head -n1 | cut -c 10-)
+SUBJECT=$(grep -E '^Subject:' ${EMAIL} | head -n1 | cut -c 10-)
 [ $? -ne 0 ] && _exit "Subject wasn't present in the patch provided"
 
 # All the remaining arguments are passed to git send-email directly


### PR DESCRIPTION
grep 3.8 has marked egrep deprecated:

  egrep: warning: egrep is obsolescent; using grep -E

Thus update the script to use "grep -E".

Signed-off-by: Qu Wenruo <wqu@suse.com>