### PR TITLE
btrfs-workflow: use histogram diff algorithm

### DIFF
--- a/configs/gitconfig
+++ b/configs/gitconfig
@@ -3,3 +3,5 @@
 	thread = shallow
 [alias]
 	fixes = show -s --pretty='format:%h (\"%s\")'
+[diff]
+	algorithm = histogram


### PR DESCRIPTION
This generates a much more human-friendly diff, other than the default greedy diff algorithm.

This would be especially handy for various refactor.

Signed-off-by: Qu Wenruo <wqu@suse.com>