### PR TITLE
btrfs-workflow: link to btrfs-create-issue using readlink

### DIFF
--- a/scripts/btrfs-send-patches
+++ b/scripts/btrfs-send-patches
@@ -5,7 +5,7 @@ _exit() {
 	exit 1
 }
 
-DIR=$(dirname $0)
+DIR=$(dirname $(readlink -f $0))
 
 MSG_ID=""
 EMAIL=""


### PR DESCRIPTION
Determine the actual directory for btrfs-create-issue, use readlink.