### PR TITLE
workflow: btrfs-send-patches: ignore cases for 'Message-ID'

### DIFF
--- a/scripts/btrfs-send-patches
+++ b/scripts/btrfs-send-patches
@@ -38,11 +38,11 @@ done
 
 [ -z "$EMAIL" ] && _exit "Must specify a file or directory to send"
 
-MSG_ID=$(grep 'Message-Id' ${EMAIL})
+MSG_ID=$(grep -i 'Message-Id' ${EMAIL})
 [ $? -ne 0 ] && _exit "Message-Id wasn't present in the patch provided"
 
 MSG_ID=$(echo ${MSG_ID} | \
-	python -c 'import re,sys; print(re.match("Message-Id: <(.*)>", sys.stdin.read())[1])')
+	python -c 'import re,sys; print(re.match("Message-Id: <(.*)>", sys.stdin.read(), re.IGNORECASE)[1])')
 [ $? -ne 0 ] && _exit "Message-Id couldn't be extracted from the patch provided"
 
 # Just incase somebody includes 'Subject:' in their commit body


### PR DESCRIPTION
[BUG]
With git updated to 2.41.0, btrfs-send-patches no longer works:

$ ~/btrfs/workflow/scripts/btrfs-send-patches --to linux-btrfs@vger.kernel.org 0001-btrfs-do-not-ASSERT-on-duplicated-global-roots.patch Message-Id wasn't present in the patch provided

[CAUSE]
Git 2.41.0 changed the tag 'Message-Id' to 'Message-ID' (note the tailing 'd' is changed to upper case).

But the script btrfs-send-patches is checking the message-id using the old format, thus it failed to locate the message id of the newly generated patches.

[FIX]
Update btrfs-send-patches scripts to ignore cases on 'Message-ID', this involves two parts:

- Grep of 'Message-ID'
- Python regex matching 'Message-ID'