### PR TITLE
workflow: do not use STDIN as a file

### DIFF
--- a/scripts/btrfs-checkpatch
+++ b/scripts/btrfs-checkpatch
@@ -18,8 +18,9 @@ cd $(dirname $MYPATH)
 	--root $DIR $TMPFILE
 [ $? -ne 0 ] && errors=$(( errors + 1))
 
-cat $TMPFILE | grep -E "^\+" | sed 's/^\+//' | \
-	$DIR/scripts/kernel-doc -v -none -Werror '&STDIN'
+cat $TMPFILE | grep -E "^\+" | sed 's/^\+//' > $TMPFILE.2
+mv $TMPFILE.2 $TMPFILE
+$DIR/scripts/kernel-doc -v -none -Werror $TMPFILE
 [ $? -ne 0 ] && errors=$(( errors + 1))
 
 rm -f $TMPFILE


### PR DESCRIPTION
[BUG]
Recently the commit hook no longer works as we're using &STDIN as a file to pass it into kernel-doc:

  Error: Cannot find file &STDIN
  1 warnings as errors
  Checkpatch found errors, would you like to fix them up? (Yn) n

[CAUSE]
I'm not sure if it's possible to redirect a pipe and pass it to a program.

Maybe it's some other part of the script stack causing something wrong.

[FIX]
Although I do not have a perfect reason to explain the problem, I can always play it safe, just redirect the output and save it as a file, then parse it to kernel-doc.